### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ afl-dyninst: afl-dyninst.o
 		-o afl-dyninst afl-dyninst.o \
 		-lcommon \
 		-liberty \
+		-lboost_system \
 		-ldyninstAPI 
 
 libAflDyninst.so: libAflDyninst.cpp


### PR DESCRIPTION
added -lboost_system to avoid undefined reference to boost::system::generic_category() error